### PR TITLE
Add spec for functions.sum method

### DIFF
--- a/src/test/scala/com/github/mrpowers/spark/models/FunctionsSpecModels.scala
+++ b/src/test/scala/com/github/mrpowers/spark/models/FunctionsSpecModels.scala
@@ -1,0 +1,4 @@
+package com.github.mrpowers.spark.models
+
+case class SumNumericInput(colA: Option[Double])
+case class SumNumericOutput(sum: Option[Double])

--- a/src/test/scala/com/github/mrpowers/spark/spec/sql/FunctionsSpec.scala
+++ b/src/test/scala/com/github/mrpowers/spark/spec/sql/FunctionsSpec.scala
@@ -1,13 +1,12 @@
 package com.github.mrpowers.spark.spec.sql
 
-import org.scalatest._
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{StructType, _}
-
-import com.github.mrpowers.spark.spec.SparkSessionTestWrapper
-
 import com.github.mrpowers.spark.fast.tests.DataFrameComparer
+import com.github.mrpowers.spark.models._
+import com.github.mrpowers.spark.spec.SparkSessionTestWrapper
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{StructType, _}
+import org.scalatest._
 
 class FunctionsSpec extends FunSpec with SparkSessionTestWrapper with DataFrameComparer {
 
@@ -1526,7 +1525,24 @@ class FunctionsSpec extends FunSpec with SparkSessionTestWrapper with DataFrameC
   }
 
   describe("#sum") {
-    pending
+    describe("(when column has only null values)") {
+      it("returns null") {
+        val sourceDF = Seq(SumNumericInput(None), SumNumericInput(None)).toDF
+        val actualDF = sourceDF.agg(sum("colA") as "sum")
+        val expectedDF = Seq(SumNumericOutput(None)).toDF
+
+        assertSmallDataFrameEquality(actualDF, expectedDF)
+      }
+    }
+    describe("(when column has at-least one non null value)") {
+      it("returns the sum of a real numbers") {
+        val sourceDF = Seq(SumNumericInput(Some(200.50)), SumNumericInput(Some(-10.0)), SumNumericInput(Some(10)), SumNumericInput(Some(-30)), SumNumericInput(None)).toDF
+        val actualDF = sourceDF.agg(sum("colA") as "sum")
+        val expectedDF = Seq(SumNumericOutput(Some(170.5))).toDF
+
+        assertSmallDataFrameEquality(actualDF, expectedDF)
+      }
+    }
   }
 
   describe("#sumDistinct") {


### PR DESCRIPTION
I have included a models package to aid to sourceDF and expectedDF creation. The case class Name follows the format Function_Spec_NameDatatypeInput/Output. It would also help with issue where expected and actual schema don't match because of nullable property as we explicitly specify Nullability using Options. Let me know what you think of this approach.