### PR TITLE
Add spec Dataset.union

### DIFF
--- a/src/test/scala/com/github/mrpowers/spark/models/DatasetSpecModels.scala
+++ b/src/test/scala/com/github/mrpowers/spark/models/DatasetSpecModels.scala
@@ -1,0 +1,4 @@
+package com.github.mrpowers.spark.models
+
+case class UnionAnyInput(name: String, age: Int, response: Option[String])
+case class UnionAnyOutput(name: String, age: Int, response: Option[String])

--- a/src/test/scala/com/github/mrpowers/spark/spec/sql/DatasetSpec.scala
+++ b/src/test/scala/com/github/mrpowers/spark/spec/sql/DatasetSpec.scala
@@ -1,11 +1,12 @@
 package com.github.mrpowers.spark.spec.sql
 
-import org.scalatest._
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{Column, Row}
-import org.apache.spark.sql.types.{StructType, _}
-import com.github.mrpowers.spark.spec.SparkSessionTestWrapper
 import com.github.mrpowers.spark.fast.tests.{DataFrameComparer, RDDComparer}
+import com.github.mrpowers.spark.models._
+import com.github.mrpowers.spark.spec.SparkSessionTestWrapper
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{StructType, _}
+import org.apache.spark.sql.{Column, Row}
+import org.scalatest._
 
 class DatasetSpec
     extends FunSpec
@@ -1155,7 +1156,16 @@ class DatasetSpec
   }
 
   describe("#union") {
-    pending
+    it("combines entries of datasets with same schema") {
+      val juniorParticipants = Seq(UnionAnyInput("Alice Jr", 12, Some("Good game")), UnionAnyInput("Bob Jr", 17, None)).toDS
+      val seniorParticipants = Seq(UnionAnyInput("Alice Sr", 52, Some("Good Play")), UnionAnyInput("Bob Sr", 47, None)).toDS
+
+      val actualDS = juniorParticipants.union(seniorParticipants)
+
+      val expectedDS = Seq(UnionAnyOutput("Alice Jr", 12, Some("Good game")), UnionAnyOutput("Bob Jr", 17, None), UnionAnyOutput("Alice Sr", 52, Some("Good Play")), UnionAnyOutput("Bob Sr", 47, None)).toDS
+
+      assertSmallDataFrameEquality(actualDS.toDF, expectedDS.toDF)
+    }
   }
 
   describe("#unpersist") {


### PR DESCRIPTION
Added spec for Union Dataset Spec, I noticed in the DatasetSpec DataFrames where created, I assumed DatasetSpec to contains specs relating to DS and went ahead and created source as DataSet. But noticed we don't have a dataset asserter hence resorted to actualDS and expectedDS conversion to DF for assertion. Is my assumption correct?