### PR TITLE
Revert "Add spec for functions.array_contains"

### DIFF
--- a/src/test/scala/com/github/mrpowers/spark/spec/sql/FunctionsSpec.scala
+++ b/src/test/scala/com/github/mrpowers/spark/spec/sql/FunctionsSpec.scala
@@ -135,30 +135,7 @@ class FunctionsSpec extends FunSpec with SparkSessionTestWrapper with DataFrameC
   }
 
   describe("#array_contains") {
-
-    it("returns true if the array contains a value") {
-
-      val sourceDF = Seq(
-        (1, Array("bob", "cat", "dog")),
-        (1, Array("mike", "phil", "greg")),
-        (1, Array("dog"))
-      ).toDF("number", "words")
-
-      val actualDF = sourceDF.withColumn(
-        "has_dog",
-        array_contains(col("words"), "dog")
-      )
-
-      val expectedDF = Seq(
-        (1, Array("bob", "cat", "dog"), true),
-        (1, Array("mike", "phil", "greg"), false),
-        (1, Array("dog"), true)
-      ).toDF("number", "words", "has_dog")
-
-      assertSmallDataFrameEquality(actualDF, expectedDF)
-
-    }
-
+    pending
   }
 
   describe("#array") {


### PR DESCRIPTION
Reverts MrPowers/spark-spec#50

com.github.mrpowers.spark.fast.tests.DataFrameSchemaMismatch: Actual Schema:
StructType(StructField(number,IntegerType,false), StructField(words,ArrayType(StringType,true),true), StructField(has_dog,BooleanType,true))
Expected Schema:
StructType(StructField(number,IntegerType,false), StructField(words,ArrayType(StringType,true),true), StructField(has_dog,BooleanType,false))