### PR TITLE
Travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
 language: scala
+cache:
+  directories:
+    - $HOME/.ivy2
+    - $HOME/spark
+    - $HOME/.cache/pip
+    - $HOME/.pip-cache
+    - $HOME/.sbt/launchers
 scala:
   - 2.11.8
+
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ cache:
   directories:
     - $HOME/.ivy2
     - $HOME/spark
-    - $HOME/.cache/pip
-    - $HOME/.pip-cache
     - $HOME/.sbt/launchers
 scala:
   - 2.11.8
-
 sudo: false


### PR DESCRIPTION
Adding Travis Config to cache downloaded dependencies, leading to faster builds and test, noticing a improvement of 1min in test times after caching. https://travis-ci.org/MrPowers/spark-spec/builds evident from build history for builds 41, 42 and 43. 